### PR TITLE
Align `UpdateOverride` with IDs of contextmenu items

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -11,24 +11,12 @@ static NOTIFYICONDATAW s_notification_data;
 static UINT s_wm_taskbar_created;
 static int s_last_update_override = -1;
 
-static int map_override_to_item(UpdateOverride override)
-{
-    switch (override) {
-    case UpdateOverride_Light:
-        return ID_CONTEXTMENU_FORCELIGHTMODE;
-    case UpdateOverride_Dark:
-        return ID_CONTEXTMENU_FORCEDARKMODE;
-    default:
-        return ID_CONTEXTMENU_SWITCHAUTOMATICALLY;
-    }
-}
-
 void menu_apply_override(UpdateOverride override)
 {
     if (s_last_update_override >= 0) {
-        CheckMenuItem(s_menu, map_override_to_item(s_last_update_override), MF_BYCOMMAND | MF_UNCHECKED);
+        CheckMenuItem(s_menu, s_last_update_override, MF_BYCOMMAND | MF_UNCHECKED);
     }
-    CheckMenuItem(s_menu, map_override_to_item(override), MF_BYCOMMAND | MF_CHECKED);
+    CheckMenuItem(s_menu, override, MF_BYCOMMAND | MF_CHECKED);
     s_last_update_override = override;
     update_run(override);
 }

--- a/src/update.h
+++ b/src/update.h
@@ -1,9 +1,10 @@
 #pragma once
+#include "resource.h"
 
 typedef enum Override {
-    UpdateOverride_None,
-    UpdateOverride_Light,
-    UpdateOverride_Dark,
+    UpdateOverride_None = ID_CONTEXTMENU_SWITCHAUTOMATICALLY,
+    UpdateOverride_Light = ID_CONTEXTMENU_FORCELIGHTMODE,
+    UpdateOverride_Dark = ID_CONTEXTMENU_FORCEDARKMODE,
 } UpdateOverride;
 
 void update_init();


### PR DESCRIPTION
I've been surprised what difference it makes in terms of compiler optimizations.  
The downside is that it extends the visability of the values in `resource.h` into unrelated code.  
